### PR TITLE
Modify docker tag in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'fractalwoodstories-docker-hub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                     sh """
-                        docker tag fractalwoodstories/cart-service:arm64-latest fractalwoodstories/cart-service:arm64-main
+                        docker tag fractalwoodstories/cart-service:arm64-latest fractalwoodstories/cart-service:arm64-main-${shortGitCommit}
                         docker login -u ${USERNAME} -p ${PASSWORD}
                         docker push fractalwoodstories/cart-service:arm64-main-${shortGitCommit}
                         docker logout


### PR DESCRIPTION
The docker tag in the Jenkinsfile has been updated to include the short Git commit. This change ensures that each Docker image uploaded to the Docker hub is associated with a unique version corresponding to the specific Git commit.